### PR TITLE
Release purge cache plugin

### DIFF
--- a/packages/purge-cache-plugin/package.json
+++ b/packages/purge-cache-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@riveo/payload-purge-cache-plugin",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Payload Purge Cache Plugin",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Invalid code version has been published in the NPM repository for 0.1.1. The types included in the published package contain previously removed error type, which causes typecheck on the payload repository to fail.

This issue was skipped because local payload instance prebuilds latest code of the plugin.