### PR TITLE
Make unique fields localized individually

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@riveo/payload-utils",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Payload Utils reused across projects",
   "license": "MIT",
   "type": "module",

--- a/packages/utils/src/fields/seoField.ts
+++ b/packages/utils/src/fields/seoField.ts
@@ -15,6 +15,7 @@ const seoField = (options?: SeoFieldOptions): GroupField => {
     {
       type: 'text',
       name: 'title',
+      localized: true,
       label: ({ t }) =>
         (t as TFunction<RiveoUtilsTranslationKeys>)(
           'riveo:utils:fields:seo:title',
@@ -23,6 +24,7 @@ const seoField = (options?: SeoFieldOptions): GroupField => {
     {
       type: 'textarea',
       name: 'description',
+      localized: true,
       label: ({ t }) =>
         (t as TFunction<RiveoUtilsTranslationKeys>)(
           'riveo:utils:fields:seo:description',
@@ -34,6 +36,7 @@ const seoField = (options?: SeoFieldOptions): GroupField => {
     fields.push({
       name: 'image',
       type: 'upload',
+      localized: true,
       label: ({ t }) =>
         (t as TFunction<RiveoUtilsTranslationKeys>)(
           'riveo:utils:fields:seo:image',
@@ -50,7 +53,6 @@ const seoField = (options?: SeoFieldOptions): GroupField => {
 
   return {
     interfaceName: 'SeoField',
-    localized: true,
     name: 'seo',
     label: ({ t }) =>
       (t as TFunction<RiveoUtilsTranslationKeys>)(

--- a/packages/utils/src/fields/slug/slugField.ts
+++ b/packages/utils/src/fields/slug/slugField.ts
@@ -25,7 +25,6 @@ const slugField = (options?: SlugFieldOptions): GroupField => {
       (t as TFunction<RiveoUtilsTranslationKeys>)(
         'riveo:utils:fields:slug:label',
       ),
-    localized: true,
     fields: [
       {
         admin: {
@@ -36,6 +35,7 @@ const slugField = (options?: SlugFieldOptions): GroupField => {
         unique: true,
         index: true,
         required: true,
+        localized: true,
         hooks: {
           beforeValidate: [formatSlugHook(options?.generateFrom)],
         },
@@ -51,6 +51,7 @@ const slugField = (options?: SlugFieldOptions): GroupField => {
         required: false,
         name: 'auto',
         defaultValue: true,
+        localized: true,
         admin: {
           disableListColumn: true,
           disableListFilter: true,


### PR DESCRIPTION
When group field is localized, the index in database is applied to nested fields without locale. Making individual fields localized, the indexes are composed using value and locale columns, which allows defining different values per locale.